### PR TITLE
CCS-119: CircleCI (build and push image)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
       - run:
           name: Push to ECR
           command: |
-            repo_url=repo_url=037670161673.dkr.ecr.us-east-1.amazonaws.com
+            repo_url=037670161673.dkr.ecr.us-east-1.amazonaws.com
             docker tag slack-app-staging:latest $repo_url/slack-app-staging:latest
             docker push $repo_url/slack-app-staging:latest
 


### PR DESCRIPTION
- Builds and pushes image to ECR
- Previously, we were managing tasks manually. Now we're going to use a service that auto deploys new task images to the cluster, so that logic shouldn't go into the deploy phase. This will also prevent downtime (hopefully).