### PR TITLE
HOTFIX: Refactored formatting for topics, messages, and replies

### DIFF
--- a/src/wrappers/PortalClientWrapper.py
+++ b/src/wrappers/PortalClientWrapper.py
@@ -1,3 +1,5 @@
+import json
+
 from tenacity import Retrying, wait_fixed, stop_after_attempt, retry_if_exception_type, after_log
 
 from src.clients.PortalClient import PortalClientException
@@ -70,15 +72,15 @@ class PortalClientWrapper:
 
     def create_topic(self, title, description, original_poster_slack_user_id, tag_names):
         # TODO [CCP-89] add composite PK on slack_team bc slack_user_id should not be unique
-        title = title.replace('"', r'\"')
-        description = description.replace('"', r'\"').replace('\n', '\\n')
-        tag_names = [name.replace('"', r'\"') for name in tag_names]
+        title = json.dumps(title)
+        description = json.dumps(description)
+        tag_names = [json.dumps(name) for name in tag_names]
         operation_definition = f'''
           {{
-            createTopicFromSlack(input: {{title: "{title}",
-                                          description: "{description}",
+            createTopicFromSlack(input: {{title: {title},
+                                          description: {description},
                                           originalPosterSlackUserId: "{original_poster_slack_user_id}",
-                                          tags: [{','.join([f'{{name: "{name}"}}' for name in tag_names])}]
+                                          tags: [{','.join([f'{{name: {name}}}' for name in tag_names])}]
                                         }})
             {{
               topic {{
@@ -99,13 +101,14 @@ class PortalClientWrapper:
         )
 
     def create_topic_and_user_as_original_poster(self, title, description, slack_user, tag_names):
-        title = title.replace('"', r'\"')
-        description = description.replace('"', r'\"').replace('\n', '\\n')
-        tag_names = [name.replace('"', r'\"') for name in tag_names]
+        title = json.dumps(title)
+        description = json.dumps(description)
+        tag_names = [json.dumps(name) for name in tag_names]
+
         operation_definition = f'''
             {{
-              createUserAndTopicFromSlack(input: {{title: "{title}",
-                                                    description: "{description}",
+              createUserAndTopicFromSlack(input: {{title: {title},
+                                                    description: {description},
                                                     originalPosterSlackUser: {{
                                                       id: "{slack_user.id}",
                                                       name: "{slack_user.name}",
@@ -120,7 +123,7 @@ class PortalClientWrapper:
                                                       slackTeamId: "{slack_user.team_id}"
                                                     }},
                                                     tags: [
-                                                        {','.join([f'{{name: "{name}"}}' for name in tag_names])}
+                                                        {','.join([f'{{name: {name}}}' for name in tag_names])}
                                                     ]}}) {{
                 topic {{
                   id
@@ -156,9 +159,11 @@ class PortalClientWrapper:
         self._validate_no_response_body_errors(response_body=response_body)
 
     def create_message(self, text, slack_channel_id, slack_event_ts, author_slack_user_id):
+        text = json.dumps(text)
+
         operation_definition = f'''
           {{
-            createMessageFromSlack(input: {{text: "{text}",
+            createMessageFromSlack(input: {{text: {text},
                                             slackChannelId: "{slack_channel_id}", slackUserId: "{author_slack_user_id}",
                                             originSlackEventTs: "{slack_event_ts}"}}) {{
               message {{
@@ -171,9 +176,11 @@ class PortalClientWrapper:
         self._validate_no_response_body_errors(response_body=response_body)
 
     def create_message_and_user_as_author(self, text, slack_channel_id, slack_event_ts, slack_user):
+        text = json.dumps(text)
+
         operation_definition = f'''
           {{
-            createUserAndMessageFromSlack(input: {{text: "{text}",
+            createUserAndMessageFromSlack(input: {{text: {text},
                                             slackChannelId: "{slack_channel_id}",
                                             slackUser: {{
                                               id: "{slack_user.id}",
@@ -199,9 +206,11 @@ class PortalClientWrapper:
         self._validate_no_response_body_errors(response_body=response_body)
 
     def create_reply(self, text, slack_channel_id, slack_event_ts, slack_thread_ts, author_slack_user_id):
+        text = json.dumps(text)
+
         operation_definition = f'''
           {{
-            createReplyFromSlack(input: {{text: "{text}",
+            createReplyFromSlack(input: {{text: {text},
                                           messageOriginSlackEventTs: "{slack_thread_ts}",
                                           slackChannelId: "{slack_channel_id}",
                                           slackUserId: "{author_slack_user_id}",
@@ -216,9 +225,11 @@ class PortalClientWrapper:
         self._validate_no_response_body_errors(response_body=response_body)
 
     def create_reply_and_user_as_author(self, text, slack_channel_id, slack_event_ts, slack_thread_ts, slack_user):
+        text = json.dumps(text)
+
         operation_definition = f'''
           {{
-            createUserAndReplyFromSlack(input: {{text: "{text}",
+            createUserAndReplyFromSlack(input: {{text: {text},
                                           originSlackEventTs: "{slack_thread_ts}",
                                           slackChannelId: "{slack_channel_id}",
                                           slackUser: {{

--- a/tests/unit/test_portal_client_wrapper.py
+++ b/tests/unit/test_portal_client_wrapper.py
@@ -6,6 +6,7 @@ from src import WrapperException
 from src.domain.models.portal.SlackProfile import SlackProfile
 from src.domain.models.portal.SlackUser import SlackUser
 from src.wrappers.PortalClientWrapper import PortalClientWrapper
+from tests.common.PrimitiveFaker import PrimitiveFaker
 
 
 def test_handles_double_quotes_in_new_topic(portal_client, mocker):
@@ -83,3 +84,65 @@ def test_handles_newlines_in_new_topic_with_user(portal_client, mocker):
 
     assert 'abc\\\"123\\\"' in portal_client.mutate.call_args[1]['operation_definition']
     assert 'abc234\\nline2' in portal_client.mutate.call_args[1]['operation_definition']
+
+
+def test_handles_newlines_and_quotes_in_message(portal_client, mocker):
+    mocker.spy(portal_client, 'mutate')
+    portal_client_wrapper = PortalClientWrapper(portal_client=portal_client)
+    with pytest.raises(WrapperException):  # TODO not ideal; won't need when portal client queuing is removed
+        portal_client_wrapper.create_message(
+            text='Once upon a "time"\nIn a "galaxy" *far*, _far_ "away"...',
+            slack_channel_id=str(PrimitiveFaker('bban')),
+            slack_event_ts="1520007783.127152",
+            author_slack_user_id=1,
+        )
+
+    assert '"Once upon a \\"time\\"\\nIn a \\"galaxy\\" *far*, _far_ \\"away\\"..."' in \
+           portal_client.mutate.call_args[1]['operation_definition']
+
+
+def test_handles_newlines_and_quotes_in_message_with_new_user(portal_client, mocker):
+    mocker.spy(portal_client, 'mutate')
+    portal_client_wrapper = PortalClientWrapper(portal_client=portal_client)
+    with pytest.raises(WrapperException):  # TODO not ideal; won't need when portal client queuing is removed
+        portal_client_wrapper.create_message_and_user_as_author(
+            text='Once upon a "time"\nIn a "galaxy" *far*, _far_ "away"...',
+            slack_channel_id=str(PrimitiveFaker('bban')),
+            slack_event_ts="1520007783.127152",
+            slack_user=SlackUser(id=1, profile=SlackProfile(image_72='url')),
+        )
+
+    assert '"Once upon a \\"time\\"\\nIn a \\"galaxy\\" *far*, _far_ \\"away\\"..."' in \
+           portal_client.mutate.call_args[1]['operation_definition']
+
+
+def test_handles_newlines_and_quotes_in_reply(portal_client, mocker):
+    mocker.spy(portal_client, 'mutate')
+    portal_client_wrapper = PortalClientWrapper(portal_client=portal_client)
+    with pytest.raises(WrapperException):  # TODO not ideal; won't need when portal client queuing is removed
+        portal_client_wrapper.create_reply(
+            text='Once upon a "time"\nIn a "galaxy" *far*, _far_ "away"...',
+            slack_channel_id=str(PrimitiveFaker('bban')),
+            slack_event_ts="1520007997.137676",
+            slack_thread_ts="1520007783.127152",
+            author_slack_user_id=1,
+        )
+
+    assert '"Once upon a \\"time\\"\\nIn a \\"galaxy\\" *far*, _far_ \\"away\\"..."' in \
+           portal_client.mutate.call_args[1]['operation_definition']
+
+
+def test_handles_newlines_and_quotes_in_reply_with_new_user(portal_client, mocker):
+    mocker.spy(portal_client, 'mutate')
+    portal_client_wrapper = PortalClientWrapper(portal_client=portal_client)
+    with pytest.raises(WrapperException):  # TODO not ideal; won't need when portal client queuing is removed
+        portal_client_wrapper.create_reply_and_user_as_author(
+            text='Once upon a "time"\nIn a "galaxy" *far*, _far_ "away"...',
+            slack_channel_id=str(PrimitiveFaker('bban')),
+            slack_event_ts="1520007997.137676",
+            slack_thread_ts="1520007783.127152",
+            slack_user=SlackUser(id=1, profile=SlackProfile(image_72='url')),
+        )
+
+    assert '"Once upon a \\"time\\"\\nIn a \\"galaxy\\" *far*, _far_ \\"away\\"..."' in \
+           portal_client.mutate.call_args[1]['operation_definition']


### PR DESCRIPTION
- Ran into issues with newlines and quotes for messages and replies (same cause as previous hotfix for topics)
- Moved to using `json.dumps` which does all of the escaping we need and returns a literal string. Updated across the relevant methods and added unit tests.