### PR TITLE
SLA-87: Metadata dialog

### DIFF
--- a/src/blueprints/slack/InteractiveComponentResource.py
+++ b/src/blueprints/slack/InteractiveComponentResource.py
@@ -1,31 +1,26 @@
 import json
 from http import HTTPStatus
+from threading import Thread
 
-from flask import request
+from flask import request, current_app
 
 from src.blueprints.slack.SlackResource import SlackResource
-from src.models.exceptions.exceptions import SlackCommunicationException
 from src.models.slack.requests.SlackInteractiveComponentRequest import InteractiveComponentRequestSchema
+from src.translators.SlackInteractiveComponentTranslator import SlackInteractiveComponentTranslator
 
 
 class InteractiveComponentResource(SlackResource):
+
+    @SlackResource.authenticate
     def post(self):
         """Receive an interactive component (e.g. menu, dialog box) payload"""
         self.logger.info(f'Processing InteractiveComponent request: {request.__dict__}')
         payload = json.loads(request.form['payload'])
-        self._authenticate(payload)
         interactive_component_request = InteractiveComponentRequestSchema().load(payload).data
-        r = interactive_component_request
-        if r.is_post_topic_dialog_submission:
-            # commands = StartDiscussionCommand(slack_client_wrapper=current_app.slack_client_wrapper,
-            #                                  strand_api_client_wrapper=current_app.strand_api_client_wrapper,
-            #                                  slack_team_id=r.team.id,
-            #                                  submission=r.submission,
-            #                                  slack_user_id=r.user.id,
-            #                                  slack_channel_id=r.channel.id)
-            # Thread(target=commands.execute, daemon=True).start()
-            return {}, HTTPStatus.OK
-        else:
-            message = f'Could not interpret slack request: {r}'
-            self.logger.error(message)
-            raise SlackCommunicationException(message=message)
+        translator = SlackInteractiveComponentTranslator(
+            slack_interactive_component_request=interactive_component_request,
+            slack_client_wrapper=current_app.slack_client_wrapper,
+            strand_api_client_wrapper=current_app.strand_api_client_wrapper
+        )
+        Thread(target=translator.translate, daemon=True).start()
+        return {}, HTTPStatus.OK

--- a/src/blueprints/slack/SlackResource.py
+++ b/src/blueprints/slack/SlackResource.py
@@ -1,3 +1,5 @@
+import json
+
 from flask import current_app, request
 from flask_restful import Resource
 
@@ -17,7 +19,10 @@ class SlackResource(Resource):
 
         def wrapper(*args, **kwargs):
             get_logger('Flask').debug(f'Request args: {request.get_json()}')
-            payload = request.get_json()
+            payload = {
+                'application/json': lambda: request.get_json(),
+                'application/x-www-form-urlencoded': lambda: json.loads(request.form['payload'])
+            }[request.headers.environ.get('CONTENT_TYPE')]()
             if payload['token'] not in current_app.slack_verification_tokens:
                 message = 'Invalid slack verification token'
                 get_logger('Flask').error(message)

--- a/src/commands/SendEditMetadataDialogCommand.py
+++ b/src/commands/SendEditMetadataDialogCommand.py
@@ -1,0 +1,16 @@
+from src.commands.Command import Command
+from src.models.slack.outgoing.dialogs import EditMetadataDialog
+
+
+class SendEditMetadataDialogCommand(Command):
+    def __init__(self, slack_client_wrapper, slack_team_id, trigger_id, strand_id):
+        super().__init__(slack_client_wrapper=slack_client_wrapper)
+        self.slack_team_id = slack_team_id
+        self.trigger_id = trigger_id
+        self.strand_id = strand_id
+
+    def execute(self):
+        log_msg = f'Executing SendEditMetadataDialogCommand for {self.slack_team_id} with trigger {self.trigger_id}'
+        self.logger.info(log_msg)
+        self.slack_client_wrapper.send_dialog(trigger_id=self.trigger_id, slack_team_id=self.slack_team_id,
+                                              dialog=EditMetadataDialog(strand_id=self.strand_id))

--- a/src/models/exceptions/exceptions.py
+++ b/src/models/exceptions/exceptions.py
@@ -5,7 +5,7 @@ class SlackCommunicationException(SLAException):
     """Raise when there's an over-the-wire issue receiving a request/response from Slack"""
 
 
-class SlackUnexpectedPayloadException(SLAException):
+class SlackTranslationException(SLAException):
     """Raise when there's a payload-related issue receiving a request/response from Slack"""
 
 
@@ -13,7 +13,7 @@ class StrandCommunicationException(SLAException):
     """Raise when there's an over-the-wire issue receiving a request/response from Strand"""
 
 
-class StrandUnexpectedPayloadException(SLAException):
+class StrandTranslationException(SLAException):
     """Raise when there's a payload-related issue receiving a request/response from Strand"""
 
 
@@ -22,4 +22,4 @@ class UnexpectedStateException(SLAException):
 
 
 class UnauthorizedException(SLAException):
-    """Raised when caller is not an authenticated user with appropriate authorization"""
+    """Raise when caller is not an authenticated user with appropriate authorization"""

--- a/src/models/slack/elements/SlackChannel.py
+++ b/src/models/slack/elements/SlackChannel.py
@@ -1,8 +1,12 @@
-from collections import namedtuple
-
 from marshmallow import Schema, fields, post_load
 
-SlackChannel = namedtuple(typename='Channel', field_names='id name')
+from src.models.Model import Model
+
+
+class SlackChannel(Model):
+    def __init__(self, id, name):
+        self.id = id
+        self.name = name
 
 
 class SlackChannelSchema(Schema):

--- a/src/models/slack/elements/SlackDialog.py
+++ b/src/models/slack/elements/SlackDialog.py
@@ -1,0 +1,19 @@
+import json
+from copy import deepcopy
+from typing import List
+
+from src.models.Model import Model
+from src.models.slack.elements.SlackElement import SlackElement
+
+
+class SlackDialog(Model):
+    def __init__(self, title, submit_label, callback_id, elements):
+        self.title = title
+        self.submit_label = submit_label
+        self.callback_id = callback_id
+        self.elements: List[SlackElement] = elements
+
+    def to_json(self):
+        result = deepcopy(vars(self))
+        result['elements'] = [json.loads(x.to_json()) for x in self.elements]
+        return json.dumps(result)

--- a/src/models/slack/elements/SlackElement.py
+++ b/src/models/slack/elements/SlackElement.py
@@ -1,0 +1,12 @@
+from src.models.Model import Model
+
+
+class SlackElement(Model):
+    def __init__(self, label, name, type, max_length=None, hint=None):
+        self.label = label
+        self.name = name
+        self.type = type
+        if max_length:
+            self.max_length = max_length
+        if hint:
+            self.hint = hint

--- a/src/models/slack/elements/SlackTeam.py
+++ b/src/models/slack/elements/SlackTeam.py
@@ -1,8 +1,11 @@
-from collections import namedtuple
-
 from marshmallow import Schema, fields, post_load
 
-SlackTeam = namedtuple(typename='Team', field_names='id')
+from src.models.Model import Model
+
+
+class SlackTeam(Model):
+    def __init__(self, id):
+        self.id = id
 
 
 class SlackTeamSchema(Schema):

--- a/src/models/slack/outgoing/actions.py
+++ b/src/models/slack/outgoing/actions.py
@@ -2,10 +2,10 @@ from src.models.slack.elements.SlackAction import SlackAction
 
 
 class EditMetadataButton(SlackAction):
-    def __init__(self):
+    def __init__(self, value=''):
         super().__init__(
             name='edit_metadata',
             text='Edit Metadata',
             type='button',
-            value='edit'
+            value=value
         )

--- a/src/models/slack/outgoing/attachments.py
+++ b/src/models/slack/outgoing/attachments.py
@@ -9,6 +9,6 @@ class EditMetadataButtonAttachment(SlackAttachment):
             color='#3AA3E3',
             attachment_type='default',
             type='button',
-            value=strand_id,
-            actions=[EditMetadataButton()]
+            value='edit',
+            actions=[EditMetadataButton(value=strand_id)]
         )

--- a/src/models/slack/outgoing/dialogs.py
+++ b/src/models/slack/outgoing/dialogs.py
@@ -1,79 +1,22 @@
-from collections import namedtuple
+from src.models.slack.elements.SlackDialog import SlackDialog
+from src.models.slack.elements.SlackElement import SlackElement
 
-# TODO refactor this out of namedtuple, use a class SlackDialogSubmitStrand(SlackDialogModel)
 
-PostTopicDialogType = namedtuple('PostTopicDialogType', 'callback_id value')
+class EditMetadataDialog(SlackDialog):
+    callback_id_prefix = 'edit_metadata'
 
-_post_topic_dialog_callback_id = 'post_topic_dialog'
-POST_TOPIC_DIALOG = PostTopicDialogType(
-    callback_id=_post_topic_dialog_callback_id,
-    value={
-        'title': 'Post Topic',
-        'submit_label': 'Discuss',
-        'callback_id': _post_topic_dialog_callback_id,
-        'elements': [
-            {
-                'label': 'Title',
-                'name': 'title',
-                'type': 'text',
-            },
-            {
-                'label': 'Description',
-                'name': 'description',
-                'type': 'textarea',
-                'max_length': 500,
-            },
-            {
-                'label': 'Tags',
-                'name': 'tags',
-                'type': 'text',
-                'hint': 'Please separate with commas. E.g. "Python, React, MySQL"',
-            }
+    def __init__(self, strand_id):
+        super().__init__(
+            title='Edit Metadata',
+            submit_label='Save',
+            callback_id=f'{self.callback_id_prefix}-{strand_id}',
+            elements=self._generate_elements()
+        )
+
+    @staticmethod
+    def _generate_elements():
+        return [
+            SlackElement(label='Title', name='title', type='text'),
+            SlackElement(label='Tags', name='tags', type='text',
+                         hint='Please separate with commas. E.g. "Python, React, MySQL"')
         ]
-    }
-)
-
-POST_TOPIC_DIALOG_WITH_CHANNEL_OPTION = PostTopicDialogType(
-    callback_id=_post_topic_dialog_callback_id,
-    value={
-        'title': 'Post Topic',
-        'submit_label': 'Discuss',
-        'callback_id': _post_topic_dialog_callback_id,
-        'elements': [
-            {
-                'label': 'Title',
-                'name': 'title',
-                'type': 'text',
-            },
-            {
-                'label': 'Description',
-                'name': 'description',
-                'type': 'textarea',
-                'max_length': 500,
-            },
-            {
-                'label': 'Tags',
-                'name': 'tags',
-                'type': 'text',
-                'hint': 'Please separate with commas. E.g. "Python, React, MySQL"',
-            },
-            {
-                'label': 'Share with channel?',
-                'name': 'share_with_current_channel',
-                'type': 'select',
-                'value': 'false',
-                'options': [
-                    {
-                        'label': 'Yes',
-                        'value': 'true'
-                    },
-                    {
-                        'label': 'No',
-                        'value': 'false'
-                    }
-                ],
-                'hint': 'The topic will be shared in this channel.'
-            }
-        ]
-    }
-)

--- a/src/models/slack/requests/SlackInteractiveComponentRequest.py
+++ b/src/models/slack/requests/SlackInteractiveComponentRequest.py
@@ -1,19 +1,24 @@
+import json
+from copy import deepcopy
+
 from marshmallow import Schema, fields, post_load
 
-from src.models.slack.outgoing.dialogs import POST_TOPIC_DIALOG
 from src.models.Model import Model
-from src.models.slack.elements.SlackChannel import SlackChannelSchema
-from src.models.slack.elements.SlackTeam import SlackTeamSchema
-from src.models.slack.elements.SlackUser import SlackUserSchema
 from src.models.slack.elements.SlackAction import SlackActionSchema
+from src.models.slack.elements.SlackChannel import SlackChannelSchema
 from src.models.slack.elements.SlackMessage import SlackMessageSchema
 from src.models.slack.elements.SlackSubmission import SlackSubmissionSchema
+from src.models.slack.elements.SlackTeam import SlackTeamSchema
+from src.models.slack.elements.SlackUser import SlackUserSchema
+from src.models.slack.outgoing.actions import EditMetadataButton
+from src.models.slack.outgoing.dialogs import EditMetadataDialog
 
 
 class SlackInteractiveComponentRequest(Model):
-    def __init__(self, callback_id, team, user, channel, trigger_id=None, response_url=None, actions=None,
+    def __init__(self, callback_id, team, user, channel, token, trigger_id=None, response_url=None, actions=None,
                  submission=None, original_message=None, type=None):
         self.type = type
+        self.token = token
         self.actions = actions
         self.callback_id = callback_id
         self.team = team
@@ -24,19 +29,35 @@ class SlackInteractiveComponentRequest(Model):
         self.channel = channel
         self.trigger_id = trigger_id
 
+    def to_json(self):
+        result = deepcopy(vars(self))
+        result['actions'] = [json.loads(x.to_json()) for x in self.actions] if self.actions else None
+        result['team'] = json.loads(self.team.to_json()) if self.team else None
+        result['original_message'] = json.loads(self.original_message.to_json()) if self.original_message else None
+        result['submission'] = json.loads(self.submission.to_json()) if self.submission else None
+        result['user'] = json.loads(self.user.to_json()) if self.user else None
+        result['channel'] = json.loads(self.channel.to_json()) if self.channel else None
+        return json.dumps(result)
+
     @property
-    def is_post_topic_dialog_submission(self):
-        return self.type == 'dialog_submission' and self.callback_id == POST_TOPIC_DIALOG.callback_id
+    def is_edit_metadata_dialog_submission(self):
+        callback_id_prefix = self.callback_id.split('-')[0]
+        return self.type == 'dialog_submission' and callback_id_prefix == EditMetadataDialog.callback_id_prefix
+
+    @property
+    def is_edit_metadata_button(self):
+        return self.actions and self.actions[0].name == EditMetadataButton().name
 
 
 class InteractiveComponentRequestSchema(Schema):
     type = fields.String()
+    token = fields.String(required=True)
     actions = fields.Nested(SlackActionSchema, many=True)
     callback_id = fields.String(required=True)
     team = fields.Nested(SlackTeamSchema, required=True)
-    original_message = fields.Nested(SlackMessageSchema)
+    original_message = fields.Nested(SlackMessageSchema, allow_none=True)
     response_url = fields.String()
-    submission = fields.Nested(SlackSubmissionSchema)
+    submission = fields.Nested(SlackSubmissionSchema, allow_none=True)
     user = fields.Nested(SlackUserSchema, required=True)
     trigger_id = fields.String()
     channel = fields.Nested(SlackChannelSchema, required=True)

--- a/src/services/parent/EditStrandMetadataService.py
+++ b/src/services/parent/EditStrandMetadataService.py
@@ -1,0 +1,21 @@
+from threading import Thread
+
+from src.commands.SendEditMetadataDialogCommand import SendEditMetadataDialogCommand
+from src.services.Service import Service
+from src.utilities.database import db_session
+
+
+class EditStrandMetadataService(Service):
+    def __init__(self, slack_team_id, trigger_id, slack_client_wrapper, strand_id):
+        super().__init__(slack_client_wrapper=slack_client_wrapper)
+        self.slack_team_id = slack_team_id
+        self.trigger_id = trigger_id
+        self.strand_id = strand_id
+
+    @db_session
+    def execute(self, session):
+        self.logger.debug(f'Providing edit metadata dialog to trigger {self.trigger_id} on team {self.slack_team_id}')
+        command = SendEditMetadataDialogCommand(slack_client_wrapper=self.slack_client_wrapper,
+                                                strand_id=self.strand_id, slack_team_id=self.slack_team_id,
+                                                trigger_id=self.trigger_id)
+        Thread(target=command.execute, daemon=True).start()

--- a/src/translators/SlackInteractiveComponentTranslator.py
+++ b/src/translators/SlackInteractiveComponentTranslator.py
@@ -1,0 +1,22 @@
+from threading import Thread
+
+from src.services.parent.EditStrandMetadataService import EditStrandMetadataService
+from src.translators.Translator import Translator
+
+
+class SlackInteractiveComponentTranslator(Translator):
+    def __init__(self, slack_interactive_component_request, slack_client_wrapper, strand_api_client_wrapper):
+        super().__init__(slack_client_wrapper=slack_client_wrapper, strand_api_client_wrapper=strand_api_client_wrapper)
+        self.slack_interactive_component_request = slack_interactive_component_request
+
+    def translate(self):
+        self.logger.debug(f'Translating slack_interactive_component_request {self.slack_interactive_component_request}')
+        if self.slack_interactive_component_request.is_edit_metadata_button:
+            trigger_id = self.slack_interactive_component_request.trigger_id
+            slack_team_id = self.slack_interactive_component_request.team.id
+            strand_id = self.slack_interactive_component_request.actions[0].value
+            service = EditStrandMetadataService(slack_client_wrapper=self.slack_client_wrapper, trigger_id=trigger_id,
+                                                slack_team_id=slack_team_id, strand_id=strand_id)
+            Thread(target=service.execute, daemon=True).start()
+        else:
+            self.logger.debug('Ignoring interactive component request.')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,8 @@ from src import create_app
 from src.config import config
 from src.utilities.database import metadata, engine, Session
 from src.utilities.logging import get_logger
-from tests.factories.slackfactories import SlackOauthAccessResponseFactory, SlackUserFactory, SlackEventRequestFactory
+from tests.factories.slackfactories import SlackOauthAccessResponseFactory, SlackUserFactory, SlackEventRequestFactory,\
+    SlackInteractiveComponentRequestFactory
 from tests.testresources.TestSlackClient import TestSlackClient
 from tests.testresources.TestStrandApiClient import TestStrandApiClient
 from tests.utils.asserting import wait_until
@@ -15,6 +16,7 @@ from tests.utils.asserting import wait_until
 register(SlackOauthAccessResponseFactory)
 register(SlackUserFactory)
 register(SlackEventRequestFactory)
+register(SlackInteractiveComponentRequestFactory)
 
 
 # Maintenance

--- a/tests/factories/slackfactories.py
+++ b/tests/factories/slackfactories.py
@@ -33,7 +33,7 @@ class OptionFactory(factory.Factory):
     value = factory.Faker('word')
 
 
-class ActionFactory(factory.Factory):
+class SlackActionFactory(factory.Factory):
     class Meta:
         model = SlackAction
 
@@ -41,7 +41,7 @@ class ActionFactory(factory.Factory):
     selected_options = factory.List([OptionFactory.build()])
 
 
-class TeamFactory(factory.Factory):
+class SlackTeamFactory(factory.Factory):
     class Meta:
         model = SlackTeam
 
@@ -115,13 +115,14 @@ class SlackBotFactory(factory.Factory):
 
 #  TOP LEVEL
 
-class InteractiveComponentRequestFactory(factory.Factory):
+class SlackInteractiveComponentRequestFactory(factory.Factory):
     class Meta:
         model = SlackInteractiveComponentRequest
 
     type = factory.Faker('word')
     callback_id = factory.Faker('word')
-    team = factory.SubFactory(TeamFactory)
+    token = config['SLACK_VERIFICATION_TOKENS'][0]
+    team = factory.SubFactory(SlackTeamFactory)
     user = factory.SubFactory(SlackUserFactory)
     channel = factory.SubFactory(ChannelFactory)
     response_url = factory.Faker('url')

--- a/tests/func/slack/TestSlackFixtures.py
+++ b/tests/func/slack/TestSlackFixtures.py
@@ -5,7 +5,7 @@ from src.models.domain.User import User
 from tests.utils.create_in_db import insert_agent_user_installation
 
 
-class TestDmFixtures:
+class TestSlackFixtures:
     @pytest.fixture(scope='function')
     def installed_user(self, db_session) -> User:
         """Inserts Agent, User, and Installation, returning the inserted user"""

--- a/tests/func/slack/suite/test_help_dm.py
+++ b/tests/func/slack/suite/test_help_dm.py
@@ -8,12 +8,12 @@ from src.models.domain.Agent import Agent
 from src.models.domain.User import User
 from tests.common.PrimitiveFaker import PrimitiveFaker
 from tests.factories.slackfactories import SlackEventFactory
-from tests.func.slack.TestDmFixtures import TestDmFixtures
+from tests.func.slack.TestSlackFixtures import TestSlackFixtures
 from tests.utils.asserting import wait_for_extra_threads_to_die, assert_values_in_call_args_list
 
 
 @pytest.mark.usefixtures('app')
-class TestHelpDm(TestDmFixtures):
+class TestHelpDm(TestSlackFixtures):
     """Test the flows for a user receiving an ephemeral Help message"""
 
     target_endpoint = 'slack.eventresource'

--- a/tests/func/slack/suite/test_save_strand.py
+++ b/tests/func/slack/suite/test_save_strand.py
@@ -6,12 +6,12 @@ from flask import url_for
 
 from src.models.domain.User import User
 from tests.factories.slackfactories import SlackEventFactory
-from tests.func.slack.TestDmFixtures import TestDmFixtures
+from tests.func.slack.TestSlackFixtures import TestSlackFixtures
 from tests.utils.asserting import wait_for_extra_threads_to_die
 
 
 @pytest.mark.usefixtures('app')
-class TestSaveStrand(TestDmFixtures):
+class TestSaveStrand(TestSlackFixtures):
     """Test the flow for a user copy/pasting a strand into DM"""
 
     target_endpoint = 'slack.eventresource'

--- a/tests/func/slack/suite/test_send_metadata_dialog.py
+++ b/tests/func/slack/suite/test_send_metadata_dialog.py
@@ -1,0 +1,42 @@
+import json
+from urllib.parse import urlencode
+
+import pytest
+from flask import url_for
+
+from src.models.domain.User import User
+from src.models.slack.outgoing.actions import EditMetadataButton
+from tests.common.PrimitiveFaker import PrimitiveFaker
+from tests.factories.slackfactories import SlackActionFactory, SlackTeamFactory, SlackUserFactory
+from tests.func.slack.TestSlackFixtures import TestSlackFixtures
+from tests.utils.asserting import wait_for_extra_threads_to_die
+
+
+@pytest.mark.usefixtures('app')
+class TestSendMetadataDialog(TestSlackFixtures):
+    """Test ability of a user to trigger the save metadata dialog"""
+
+    target_endpoint = 'slack.interactivecomponentresource'
+    default_headers = {'Content-Type': 'application/x-www-form-urlencoded'}
+
+    def test_send_metadata_dialog(self, installed_user: User, slack_client_class,
+                                  slack_interactive_component_request_factory, baseline_thread_count, client, mocker):
+        """Send the dialog to the user when s/he clicks the button to prompt it"""
+        target_url = url_for(endpoint=self.target_endpoint)
+        fake_strand_id = str(PrimitiveFaker('ean8'))
+        fake_slack_interactive_component_request = slack_interactive_component_request_factory(
+            team=SlackTeamFactory.create(id=installed_user.agent_slack_team_id),
+            user=SlackUserFactory.create(id=installed_user.slack_user_id),
+            actions=[SlackActionFactory.create(name=EditMetadataButton(value=fake_strand_id).name)]
+        )
+        fake_trigger_id = fake_slack_interactive_component_request.trigger_id
+        payload = json.loads(fake_slack_interactive_component_request.to_json())
+        mocker.spy(slack_client_class, 'api_call')
+
+        response = client.post(path=target_url, headers=self.default_headers,
+                               data=urlencode({'payload': json.dumps(payload)}))
+        assert wait_for_extra_threads_to_die(baseline_count=baseline_thread_count), 'Extra threads timed out'
+        assert 200 <= response.status_code <= 300
+
+        assert slack_client_class.api_call.call_args[1]['method'] == 'dialog.open'
+        assert slack_client_class.api_call.call_args[1]['trigger_id'] == fake_trigger_id


### PR DESCRIPTION
In this review:
* Takes in requests that come from user clicking "Edit Metadata" --> throws back an edit strand metadata dialog
* Renamed UnexpectedPayload exceptions to Translation exceptions
* Moved the strand_id from sitting on the attachment to instead sit on the button (since that's what gets sent when the button is clicked)

Suggested review steps:
1) test_send_metadata_dialog.py
2) InteractiveComponentResource.py
3) SlackInteractiveComponentTranslator.py
4) EditStrandMetadataService.py
5) SendEditMetadataDialogCommand.py

Btw been trying to squash commits, and it's been creating merge conflict/rebase hell (hence this looks like 73 commits lol). Might look for a more robust way to do this soon

EDIT: Trying something new... squashed before PRing. I think this'll help