### PR TITLE
SLA-178: Handle new bot case

### DIFF
--- a/src/commands/InstallApplicationCommand.py
+++ b/src/commands/InstallApplicationCommand.py
@@ -1,13 +1,14 @@
 from threading import Thread
 
+from src.commands.AddStrandUserToTeamCommand import AddStrandUserToTeamCommand
 from src.commands.Command import Command
 from src.commands.CreateStrandTeamWithUserCommand import CreateStrandTeamWithUserCommand
-from src.commands.AddStrandUserToTeamCommand import AddStrandUserToTeamCommand
 from src.models.domain.Agent import Agent, AgentStatus
 from src.models.domain.Bot import Bot
 from src.models.domain.Installation import Installation
 from src.models.domain.User import User
 from src.models.slack.outgoing.messages import WelcomeSlackMessage
+from src.models.slack.responses.SlackOauthAccessResponse import SlackOauthAccessResponse
 from src.utilities.database import db_session
 
 
@@ -29,50 +30,55 @@ class InstallApplicationCommand(Command):
     @db_session
     def execute(self, session):
         self.logger.debug(f'Installing application with oauth code {self.code}')
-        slack_oauth_access_response = self.slack_client_wrapper.submit_oauth_code(code=self.code)
-        existing_agent = self._get_agent(slack_oauth_access_response=slack_oauth_access_response,
-                                           session=session)
-        existing_installer = self._get_installer(slack_oauth_access_response=slack_oauth_access_response,
-                                                   session=session)
-        existing_installation = self._get_installation(slack_oauth_access_response=slack_oauth_access_response,
-                                                         session=session)
+        response: SlackOauthAccessResponse = self.slack_client_wrapper.submit_oauth_code(code=self.code)
+        existing_agent = self._get_agent(slack_oauth_access_response=response,
+                                         session=session)
+        existing_installer = self._get_installer(slack_oauth_access_response=response,
+                                                 session=session)
+        existing_installation = self._get_installation(slack_oauth_access_response=response,
+                                                       session=session)
+        existing_bot = self._get_bot(slack_oauth_access_response=response, session=session)
+
+        if existing_bot and response.bot:
+            # An updated bot has been sent
+            self._update_bot(slack_oauth_access_response=response, session=session)
 
         if not existing_agent:
-            self._create_agent(slack_oauth_access_response=slack_oauth_access_response, session=session)
-            self._create_installer(slack_oauth_access_response=slack_oauth_access_response, session=session)
-            self._create_installation(slack_oauth_access_response=slack_oauth_access_response, session=session)
+            self._create_agent_and_bot(slack_oauth_access_response=response, session=session)
+            self._create_installer(slack_oauth_access_response=response, session=session)
+            self._create_installation(slack_oauth_access_response=response, session=session)
         elif not existing_installer:
-            self._create_installer(slack_oauth_access_response=slack_oauth_access_response, session=session)
-            self._create_installation(slack_oauth_access_response=slack_oauth_access_response, session=session)
+            self._create_installer(slack_oauth_access_response=response, session=session)
+            self._create_installation(slack_oauth_access_response=response, session=session)
         elif not existing_installation:
-            self._create_installation(slack_oauth_access_response=slack_oauth_access_response, session=session)
+            self._create_installation(slack_oauth_access_response=response, session=session)
         else:
-            self._update_installation(slack_oauth_access_response=slack_oauth_access_response, session=session)
+            self._update_installation(slack_oauth_access_response=response, session=session)
 
         # ensure DB commit before communicating with Strand API
         session.commit()
 
         if not existing_agent or not existing_agent.strand_team_id:
             command = CreateStrandTeamWithUserCommand(
-                slack_team_id=slack_oauth_access_response.team_id,
-                slack_team_name=slack_oauth_access_response.team_name,
-                slack_user_id=slack_oauth_access_response.user_id,
+                slack_team_id=response.team_id,
+                slack_team_name=response.team_name,
+                slack_user_id=response.user_id,
                 strand_api_client_wrapper=self.strand_api_client_wrapper,
                 slack_client_wrapper=self.slack_client_wrapper
             )
             Thread(target=command.execute, daemon=True).start()
         elif not existing_installer or not existing_installer.strand_user_id:
             command = AddStrandUserToTeamCommand(
-                slack_team_id=slack_oauth_access_response.team_id,
-                slack_user_id=slack_oauth_access_response.user_id,
-                strand_team_id=self._get_strand_team_id(slack_oauth_access_response=slack_oauth_access_response,
+                slack_team_id=response.team_id,
+                slack_user_id=response.user_id,
+                strand_team_id=self._get_strand_team_id(slack_oauth_access_response=response,
                                                         session=session),
                 strand_api_client_wrapper=self.strand_api_client_wrapper,
                 slack_client_wrapper=self.slack_client_wrapper
             )
             Thread(target=command.execute, daemon=True).start()
 
-        self._send_installer_welcome_message(slack_oauth_access_response=slack_oauth_access_response)
+        self._send_installer_welcome_message(slack_oauth_access_response=response)
 
     @staticmethod
     def _get_strand_team_id(slack_oauth_access_response, session):
@@ -86,7 +92,7 @@ class InstallApplicationCommand(Command):
         return agent
 
     @staticmethod
-    def _create_agent(slack_oauth_access_response, session):
+    def _create_agent_and_bot(slack_oauth_access_response, session):
         bot = Bot(access_token=slack_oauth_access_response.bot.bot_access_token,
                   user_id=slack_oauth_access_response.bot.bot_user_id,
                   agent_slack_team_id=slack_oauth_access_response.team_id)
@@ -125,13 +131,21 @@ class InstallApplicationCommand(Command):
                                     installer_agent_slack_team_id=slack_oauth_access_response.team_id)
         session.add(installation)
 
-    @staticmethod
-    def _update_installation(slack_oauth_access_response, session):
-        installation = session.query(Installation).filter(
-            Installation.installer_slack_user_id == slack_oauth_access_response.user_id,
-            Installation.installer_agent_slack_team_id == slack_oauth_access_response.team_id).one()
+    def _update_installation(self, slack_oauth_access_response, session):
+        installation = self._get_installation(slack_oauth_access_response=slack_oauth_access_response, session=session)
         installation.access_token = slack_oauth_access_response.access_token
         installation.scope = slack_oauth_access_response.scope
+
+    @staticmethod
+    def _get_bot(slack_oauth_access_response, session) -> Bot:
+        slack_team_id = slack_oauth_access_response.team_id
+        bot = session.query(Bot).filter(Bot.agent_slack_team_id == slack_team_id).one_or_none()
+        return bot
+
+    def _update_bot(self, slack_oauth_access_response, session):
+        bot = self._get_bot(slack_oauth_access_response=slack_oauth_access_response, session=session)
+        bot.access_token = slack_oauth_access_response.bot.bot_access_token
+        bot.user_id = slack_oauth_access_response.bot.bot_user_id
 
     def _send_installer_welcome_message(self, slack_oauth_access_response):
         slack_team_id = slack_oauth_access_response.team_id


### PR DESCRIPTION
When the Slack handshake sends a new bot, this will make sure the relevant `Agent`'s `Bot` gets updated with the new token, user Id

The only scenario in which I can think of this happening is in the case Jacob exhibited where he revoked the Bot's permissions. I have another ticket for handling those events as they occur. But figured this was worth handling as well, since in theory Slack could send us a new bot anytime and wouldn't be breaking any kind of contract.