### PR TITLE
SLA-189: Integrate markdown converter

### DIFF
--- a/src/models/slack/elements/SlackProfile.py
+++ b/src/models/slack/elements/SlackProfile.py
@@ -4,7 +4,7 @@ from src.models.Model import Model
 
 
 class SlackProfile(Model):
-    def __init__(self, real_name, display_name, email):
+    def __init__(self, real_name, display_name, email=None):
         self.real_name = real_name
         self.display_name = display_name
         self.email = email
@@ -13,7 +13,7 @@ class SlackProfile(Model):
 class SlackProfileSchema(Schema):
     real_name = fields.String(required=True)
     display_name = fields.String(required=True)
-    email = fields.String(required=True)
+    email = fields.String()
 
     @post_load
     def make_slack_profile(self, data):

--- a/src/services/helper/ConvertTextToGFMService.py
+++ b/src/services/helper/ConvertTextToGFMService.py
@@ -1,15 +1,68 @@
+import re
+import time
+
 from src.services.Service import Service
 
 
 class ConvertTextToGFMService(Service):
     """Given text, convert to Github Flavored Markdown"""
 
-    def __init__(self, text, slack_client_wrapper):
+    def __init__(self, text, slack_team_id, slack_client_wrapper):
         super().__init__(slack_client_wrapper=slack_client_wrapper)
         self.text = text
+        self.slack_team_id = slack_team_id
 
     def execute(self):
         """Return the converted markdown"""
         self.logger.debug(f'Converting text to GFM: {repr(self.text)}')
-        # TODO Vikas to implement
-        return self.text
+
+        # 1. Convert Bold text
+        ghm = re.sub('\*(.*?)\*', lambda x: x.group().replace('*', '**'), self.text)
+
+        # 2. No need to convert italics (_italics_), inline code (`code`), and multiline code(```code```)
+
+        # 3. Convert Strikethrough
+        ghm = re.sub('\~(.*?)\~', lambda x: x.group().replace('~', '~~'), ghm)
+
+        # 4. Convert Links and Commands
+        ghm = re.sub('<(.*?)>', self.convert_links_and_commands, ghm)
+
+        # 5. Replace newline (\n) character with two newline chracters
+        ghm = ghm.replace('\n', '\n\n')
+
+        return ghm
+
+    def convert_links_and_commands(self, matchgroup):
+        matchtext = matchgroup.group(1)
+
+        # 1. format content starting with #C as a channel link
+        if matchtext.startswith('#C'):
+            if '|' in matchtext:
+                channel_name = matchtext.split('|')[1].strip()
+            else:
+                channel = self.slack_client_wrapper.get_channel_info(self.slack_team_id, matchtext[1:])
+                channel_name = channel['name']
+            return '#{}'.format(channel_name)
+
+        # 2. format content starting with @U or @W as a user link
+        if matchtext.startswith('@U') or matchtext.startswith('@W'):
+            if '|' in matchtext:
+                username = matchtext.split('|')[1].strip()
+            else:
+                user = self.slack_client_wrapper.get_user_info(self.slack_team_id, matchtext[1:])
+                username = user.profile.display_name
+            return '@{}'.format(username)
+
+        # 3. format content starting with ! according to the rules for the special command.
+        if matchtext.startswith('!'):
+            if matchtext.startswith('!date'):
+                timestamp = int(matchtext.split('^')[1])
+                return time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(timestamp))
+
+        # 4. format URLs
+        if '|' in matchtext:
+            link_url = matchtext.split('|')[0]
+            link_name = matchtext.split('|')[1]
+            return '[{}]({})'.format(link_name, link_url)
+        else:
+            return matchtext

--- a/src/services/parent/InitiateSaveStrandService.py
+++ b/src/services/parent/InitiateSaveStrandService.py
@@ -24,7 +24,7 @@ class InitiateSaveStrandService(Service):
         log_msg = f'Saving Strand with body {self.text} for user {self.slack_user_id} on team {self.slack_team_id}'
         self.logger.debug(log_msg)
         if User.is_installer(session, self.slack_user_id, self.slack_team_id):
-            markdown_body = ConvertTextToGFMService(text=self.text,
+            markdown_body = ConvertTextToGFMService(text=self.text, slack_team_id=self.slack_team_id,
                                                     slack_client_wrapper=self.slack_client_wrapper).execute()
             strand_team_id = Agent.get_strand_team_id(session, self.slack_team_id)
             saver_strand_user_id = self._get_saver_strand_user_id(session)

--- a/src/services/parent/InitiateSaveStrandViaSlashCommandService.py
+++ b/src/services/parent/InitiateSaveStrandViaSlashCommandService.py
@@ -30,7 +30,7 @@ class InitiateSaveStrandViaSlashCommandService(Service):
                                                           slack_team_id=self.slack_team_id,
                                                           slack_user_id=self.slack_user_id,
                                                           slack_client_wrapper=self.slack_client_wrapper).execute()
-                markdown_body = ConvertTextToGFMService(text=text,
+                markdown_body = ConvertTextToGFMService(text=text, slack_team_id=self.slack_team_id,
                                                         slack_client_wrapper=self.slack_client_wrapper).execute()
                 strand_team_id = Agent.get_strand_team_id(session, self.slack_team_id)
                 saver_strand_user_id = self._get_saver_strand_user_id(session)

--- a/src/utilities/wrappers/SlackClientWrapper.py
+++ b/src/utilities/wrappers/SlackClientWrapper.py
@@ -7,6 +7,7 @@ from src.models.domain.Installation import Installation
 from src.models.exceptions.WrapperException import WrapperException
 from src.models.slack.elements.SlackUser import SlackUserSchema
 from src.models.slack.elements.SlackMessage import SlackMessageSchema
+from src.models.slack.elements.SlackChannel import SlackChannelSchema
 from src.models.slack.responses import SlackOauthAccessResponse
 from src.models.slack.responses.SlackOauthAccessResponse import SlackOauthAccessResponseSchema
 from src.utilities.database import db_session
@@ -76,6 +77,13 @@ class SlackClientWrapper:
         self._validate_response_ok(response, 'get_user_info', slack_team_id, slack_user_id)
         return self._deserialize_response_body(response_body=response, ObjectSchema=SlackUserSchema,
                                                path_to_object=['user'])
+
+    def get_channel_info(self, slack_team_id, slack_channel_id):
+        slack_client = self._get_slack_client(slack_team_id=slack_team_id)
+        response = self.standard_retrier.call(slack_client.api_call, method='channels.info', channel=slack_channel_id)
+        self._validate_response_ok(response, 'get_channel_info', slack_team_id, slack_channel_id)
+        return self._deserialize_response_body(response_body=response, ObjectSchema=SlackChannelSchema,
+                                               path_to_object=['channel'])
 
     def send_message(self, slack_team_id, slack_channel_id, text, attachments=None):
         slack_client = self._get_slack_client(slack_team_id=slack_team_id)


### PR DESCRIPTION
- Added a `get_channel_info` method to the Slack wrapper
- Made email not required on Profile schema (bots do not have emails which leads to errors when trying to get user info on a bot user)